### PR TITLE
Replace deprecated template_file with templatefile function

### DIFF
--- a/opencart-shop.tf
+++ b/opencart-shop.tf
@@ -29,7 +29,7 @@ resource "yandex_compute_instance" "opencart-vm" {
   }
 
   metadata = {
-  user-data = "${data.template_file.cloud_init_lin.rendered}"
+  user-data = templatefile("init/opencart-install.yaml", { ssh_key = "${chomp(tls_private_key.ssh.public_key_openssh)}"} )
   serial-port-enable = 1
   
 }
@@ -45,12 +45,6 @@ resource "yandex_compute_instance" "opencart-vm" {
   }
 } */
 
-data "template_file" "cloud_init_lin" {
-  template = file("init/opencart-install.yaml")
-   vars =  {
-        ssh_key = "${chomp(tls_private_key.ssh.public_key_openssh)}"
-    }
-}
 #Create ssh key
 resource "tls_private_key" "ssh" {
   algorithm = "RSA"


### PR DESCRIPTION
Running terraform scenario on Apple Silicon M1 fails:
`
terraform init

Initializing the backend...

Initializing provider plugins...
- Finding latest version of yandex-cloud/yandex...
- Finding latest version of hashicorp/local...
- Finding latest version of hashicorp/tls...
- Finding latest version of hashicorp/template...
- Installing yandex-cloud/yandex v0.80.0...
- Installed yandex-cloud/yandex v0.80.0 (unauthenticated)
- Installing hashicorp/local v2.2.3...
- Installed hashicorp/local v2.2.3 (unauthenticated)
- Installing hashicorp/tls v4.0.3...
- Installed hashicorp/tls v4.0.3 (unauthenticated)
╷
│ Error: Incompatible provider version
│
│ Provider registry.terraform.io/hashicorp/template v2.2.0 does not have a package available for your current platform, darwin_arm64.
│
│ Provider releases are separate from Terraform CLI releases, so not all providers are available for all platforms. Other versions of this provider may
│ have different platforms supported.
`

This is because template provider was deprecated and archived before the existence of M1 (darwin_arm64) releases. (see: https://discuss.hashicorp.com/t/template-v2-2-0-does-not-have-a-package-available-mac-m1/35099/2).

I've replaces template_file with templatefile function to fix this issue.